### PR TITLE
fix(gulp): ensured setup task runs before npm publish

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -49,7 +49,7 @@ function spawnp(proc, args = [], opts = { "stdio": `inherit` }) {
     });
 }
 
-gulp.task(`changelog`, () => {
+gulp.task(`changelog`, [`setup`], () => {
     return standardChangelog({
         "preset": `angular`,
         "releaseCount": 0
@@ -191,6 +191,5 @@ gulp.task(`clean`, [`clean:docs`, `clean:manual`]);
 gulp.task(`test:install`, [`nsp`, `snyk`, `bithound`]);
 gulp.task(`test:publish`, [`test:install`, `package`]);
 gulp.task(`prepublish`, [`test:publish`]);
-gulp.task(`pretest`, [`setup`]);
 gulp.task(`test`, [`test:install`, `lint`]);
 gulp.task(`default`, [`test`]);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

**Before** submitting a pull request, please make sure the following is done:

- [x] Fork the repo and create your branch from `master`
- [x] Branch naming follows `gils{issue-number[0-9]+}-{pull-request-description}` notation
- [x] PR has tests / docs demo, and is linted (`npm test`).
- [x] If you've added code that should be tested, add tests!
- [x] If you've changed APIs, update the documentation.
- [x] Commits are done through [commitizen](https://commitizen.github.io/cz-cli/) `git cz`
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

`gulp setup` was described in the gulpfile but not required during a travis build